### PR TITLE
Bugfix/complex path rule not working

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@
 build:
 	go build -o turtle-proxy
 
+test:
+	go test ./...
+
 release:
 	GOOS=linux GOARCH=amd64 go build -o turtle-proxy-linux-x64
 	GOOS=darwin GOARCH=amd64 go build -o turtle-proxy-darwin-x64

--- a/delay/matcher.go
+++ b/delay/matcher.go
@@ -37,18 +37,24 @@ func (g *gorillaMatcher) Add(method string, path string) string {
 	return matchId
 }
 
-func (g *gorillaMatcher) Match(method string, path string) bool {
+func (g *gorillaMatcher) Match(method string, path string) (string, bool) {
 	req, err := http.NewRequest(method, path, nil)
 	if err != nil {
-		// TODO use a proper logger
-		log.Printf("Error matching path: %s\n", err)
-		return false
+		log.Panicf("matcher: error matching path: %s\n", err)
 	}
 
 	var routeMatch mux.RouteMatch
 	ok := g.router.Match(req, &routeMatch)
+	if !ok {
+		return "", false
+	}
 
-	return ok
+	pathTemplate, err := routeMatch.Route.GetPathTemplate()
+	if err != nil {
+		log.Panic("matcher: matched a route with no template!")
+	}
+
+	return pathTemplate, ok
 }
 
 func (g *gorillaMatcher) Remove(id string) {

--- a/delay/matcher_test.go
+++ b/delay/matcher_test.go
@@ -1,0 +1,125 @@
+package delay
+
+import (
+	"testing"
+)
+
+func TestGorillaMatcher(t *testing.T) {
+	matcher := newGorillaMatcher()
+
+	pathExpression := "/path/{id}"
+	method := "GET"
+
+	matcher.Add(method, pathExpression)
+
+	t.Run("Should return pathExpression for explicit path", func(t *testing.T) {
+		concretePath := "/path/12093"
+
+		expression, ok := matcher.Match(method, concretePath)
+
+		if !ok {
+			t.Fatalf("Expected to find a match for: %s. Got none.", concretePath)
+		}
+
+		if expression != pathExpression {
+			t.Fatalf("Expected expression to be: %s. Got %s.", pathExpression, expression)
+		}
+	})
+
+	t.Run("Should not math unrelated paths", func(t *testing.T) {
+		concretePath := "/pat"
+
+		_, ok := matcher.Match(method, concretePath)
+
+		if ok {
+			t.Fatalf("Expected to not find a match for: %s. Got one.", concretePath)
+		}
+	})
+	t.Run("Should not match subpaths ", func(t *testing.T) {
+		concretePath := "/path/12093/lol/201983"
+
+		_, ok := matcher.Match(method, concretePath)
+
+		if ok {
+			t.Fatalf("Expected to not find a match for: %s. Got one.", concretePath)
+		}
+	})
+}
+
+type TestRule struct {
+	Method string
+	Path   string
+}
+
+func TestGorillaMatcherMultipleRules(t *testing.T) {
+	matcher := newGorillaMatcher()
+
+	rule1 := TestRule{Method: "GET", Path: "/path"}
+	rule2 := TestRule{Method: "GET", Path: "/path/{id}"}
+	rule3 := TestRule{Method: "GET", Path: "/path/{id}/sub"}
+	rule4 := TestRule{Method: "GET", Path: "/path/{id}/sub/{id}"}
+
+	rules := []TestRule{rule1, rule2, rule3, rule4}
+
+	for _, r := range rules {
+		matcher.Add(r.Method, r.Path)
+	}
+
+	t.Run("Explicit path should match root", func(t *testing.T) {
+		concretePath := "/path"
+		method := "GET"
+
+		expression, ok := matcher.Match(method, concretePath)
+
+		if !ok {
+			t.Fatalf("Expected to find a match for: %s. Got none.", concretePath)
+		}
+
+		if expression != rule1.Path {
+			t.Fatalf("Expected expression to be: %s. Got %s.", rule1.Path, expression)
+		}
+	})
+	t.Run("1 level child leaf example match", func(t *testing.T) {
+		concretePath := "/path/12"
+		method := "GET"
+
+		expression, ok := matcher.Match(method, concretePath)
+
+		if !ok {
+			t.Fatalf("Expected to find a match for: %s. Got none.", concretePath)
+		}
+
+		if expression != rule2.Path {
+			t.Fatalf("Expected expression to be: %s. Got %s.", rule2.Path, expression)
+		}
+	})
+	t.Run("1 level child with children example match", func(t *testing.T) {
+		concretePath := "/path/12/sub"
+		method := "GET"
+
+		expression, ok := matcher.Match(method, concretePath)
+
+		if !ok {
+			t.Fatalf("Expected to find a match for: %s. Got none.", concretePath)
+		}
+
+		if expression != rule3.Path {
+			t.Fatalf("Expected expression to be: %s. Got %s.", rule3.Path, expression)
+		}
+	})
+	t.Run("2 level child leaf example match", func(t *testing.T) {
+		concretePath := "/path/12/sub/something"
+		method := "GET"
+
+		expression, ok := matcher.Match(method, concretePath)
+
+		if !ok {
+			t.Fatalf("Expected to find a match for: %s. Got none.", concretePath)
+		}
+
+		if expression != rule4.Path {
+			t.Fatalf("Expected expression to be: %s. Got %s.", rule4.Path, expression)
+		}
+	})
+
+}

--- a/delay/rule_test.go
+++ b/delay/rule_test.go
@@ -52,7 +52,7 @@ func TestRuleStorage(t *testing.T) {
 		method := "GET"
 		path := "/route"
 
-		rule := Rule{Method: method, Path: path}
+		rule := Rule{Method: method, Path: path, RequestDelay: 1}
 
 		storage.Store(rule)
 		storage.Remove(method, path)
@@ -68,7 +68,7 @@ func TestRuleStorage(t *testing.T) {
 		method := "GET"
 		path := "/route"
 
-		rule := Rule{Method: method, Path: path}
+		rule := Rule{Method: method, Path: path, RequestDelay: 1}
 
 		storage.Store(rule)
 		storage.Clear()
@@ -84,11 +84,11 @@ func TestRuleStorage(t *testing.T) {
 		method := "GET"
 
 		path := "/route"
-		rule := Rule{Method: method, Path: path}
+		rule := Rule{Method: method, Path: path, RequestDelay: 1}
 		storage.Store(rule)
 
 		path2 := "/route/{id}"
-		rule2 := Rule{Method: method, Path: path2}
+		rule2 := Rule{Method: method, Path: path2, RequestDelay: 1}
 		storage.Store(rule2)
 
 		storage.Remove(method, path)
@@ -103,6 +103,21 @@ func TestRuleStorage(t *testing.T) {
 			t.Fatalf("Expected storage to contain rule with path: %s", path2)
 		}
 	})
+	t.Run("Rule with no delay are discarded", func(t *testing.T) {
+		storage := DefaultStorage()
+
+		method := "GET"
+		path := "/route"
+
+		rule := Rule{Method: method, Path: path}
+
+		storage.Store(rule)
+		_, ok := storage.Get(method, path)
+
+		if ok {
+			t.Fatalf("Expected storage to not contain rule with path: %s", path)
+		}
+	})
 }
 
 func TestRuleStorageComplexPaths(t *testing.T) {
@@ -110,7 +125,7 @@ func TestRuleStorageComplexPaths(t *testing.T) {
 		storage := DefaultStorage()
 
 		method := "GET"
-		path := "/route"
+		path := "/route/{everything:.*}"
 		delay := 10
 
 		r := Rule{Method: method, Path: path, RequestDelay: delay}

--- a/delay/rule_test.go
+++ b/delay/rule_test.go
@@ -104,3 +104,40 @@ func TestRuleStorage(t *testing.T) {
 		}
 	})
 }
+
+func TestRuleStorageComplexPaths(t *testing.T) {
+	t.Run("Get works for sub-path", func(t *testing.T) {
+		storage := DefaultStorage()
+
+		method := "GET"
+		path := "/route"
+		delay := 10
+
+		r := Rule{Method: method, Path: path, RequestDelay: delay}
+
+		storage.Store(r)
+
+		subPath := "/route/109823/something"
+		rule, ok := storage.Get(method, subPath)
+
+		if !ok {
+			t.Fatalf("Expected storage to contain rule with path: %s", path)
+		}
+
+		if rule.Method != method {
+			t.Fatalf("Expected rule method to be: %s. Got: %s", method, rule.Method)
+		}
+
+		if rule.Path != path {
+			t.Fatalf("Expected rule path to be: %s. Got: %s", path, rule.Path)
+		}
+
+		if rule.RequestDelay != delay {
+			t.Fatalf("Expected rule request delay to be: %d. Got: %d", delay, rule.RequestDelay)
+		}
+
+		if rule.ResponseDelay != 0 {
+			t.Fatalf("Expected rule request delay to be: %d. Got: %d", delay, rule.ResponseDelay)
+		}
+	})
+}


### PR DESCRIPTION
This should fix issue #1.

The matcher should now return the original path template it matched on, so the rule storage can resolve the delay rule accordingly.

This effectively makes the RuleMatcher interface to look like:

```go
 type RuleMatcher interface {
 	Add(method string, path string) string
	Match(method string, path string) (string, bool)
 	Remove(id string)
 	Clear()
 }
```

I have also added some more tests, just to clarify the path matching rules.